### PR TITLE
Use Core18 base for Python 3.6 support (fixes #1)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: asyncy
-version: 0.0.11
+version: 0.3.4
 summary: Asyncy CLI
 description: Asyncy CLI
 grade: devel
@@ -15,26 +15,7 @@ apps:
 
 parts:
   asyncy:
-    source: https://github.com/asyncy/cli/archive/0.0.11.tar.gz
     plugin: python
     python-version: python3
     python-packages:
-    - certifi==2018.8.24
-    - chardet==3.0.4
-    - click==6.7
-    - click-alias==0.1.1a1
-    - click-didyoumean==0.0.3
-    - click-help-colors==0.4
-    - click-spinner==0.1.8
-    - emoji==0.5.0
-    - idna==2.7
-    - lark-parser==0.6.4
-    - mixpanel==4.3.2
-    - prompt-toolkit==2.0.3
-    - Pygments==2.2.0
-    - raven==6.9.0
-    - requests==2.19.1
-    - six==1.11.0
-    - storyscript==0.5.1
-    - urllib3==1.23
-    - wcwidth==0.1.7
+    - asyncy==0.3.4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,10 +4,14 @@ summary: Asyncy CLI
 description: Asyncy CLI
 grade: devel
 confinement: devmode
+base: core18
 
 apps:
   asyncy:
     command: bin/asyncy
+    environment:
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
 
 parts:
   asyncy:


### PR DESCRIPTION
The CLI uses f-string syntax at various places, a Python feature introduced in Python 3.6. From https://docs.snapcraft.io/381 we find that the default base for snaps is Ubuntu 16.04, which comes with Python 3.5 out of the box. Core18 got released pretty recently, based on Ubuntu 18.04 and with Python 3.6 available.

Core18 doesn't properly expose the LANG and LC_ALL environment variables by default, causing Click to fail because it believes it's running in ASCII mode. Those variables are now set via the 'environment' app
property in the yaml as well.